### PR TITLE
System :sepolicy: Fix bootloop on TWRP restore

### DIFF
--- a/prebuilts/api/29.0/public/domain.te
+++ b/prebuilts/api/29.0/public/domain.te
@@ -486,7 +486,8 @@ neverallow { domain -kernel with_asan(`-asan_extract') } { system_file_type vend
 
 # Don't allow mounting on top of /system files or directories
 neverallow * exec_type:dir_file_class_set mounton;
-neverallow { domain -init } { system_file_type vendor_file_type }:dir_file_class_set mounton;
+neverallow { domain -init } { system_file_type vendor_file_type }:file_class_set mounton;
+neverallow { domain -init -zygote} { system_file_type vendor_file_type }:dir mounton;
 
 # Nothing should be writing to files in the rootfs, except recovery.
 neverallow { domain -recovery } rootfs:file { create write setattr relabelto append unlink link rename };

--- a/public/domain.te
+++ b/public/domain.te
@@ -486,7 +486,8 @@ neverallow { domain -kernel with_asan(`-asan_extract') } { system_file_type vend
 
 # Don't allow mounting on top of /system files or directories
 neverallow * exec_type:dir_file_class_set mounton;
-neverallow { domain -init } { system_file_type vendor_file_type }:dir_file_class_set mounton;
+neverallow { domain -init } { system_file_type vendor_file_type }:file_class_set mounton;
+neverallow { domain -init -zygote} { system_file_type vendor_file_type }:dir mounton;
 
 # Nothing should be writing to files in the rootfs, except recovery.
 neverallow { domain -recovery } rootfs:file { create write setattr relabelto append unlink link rename };


### PR DESCRIPTION
sepolicy: Fix bootloop on TWRP restore

When TWRP restores a ROM backup, the root directory now has the wrong
selinux
context "system_file" instead of "rootfs" as it should be for Q
system-as-root.

Attempting to boot the restored ROM results in the following
error/denial
and will bootloop if the ROM is enforcing.

Therefore, added sepolicy/vendor/zygote.te on device tree.
As result, neverallow rule on domain.te must chnage.